### PR TITLE
Replace karafka/rdkafka dep with sutrolabs/rdkafka

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,11 @@
 
 source 'https://rubygems.org'
 
-plugin 'diffend'
+# plugin 'diffend'
 
 gemspec
+
+gem "rdkafka", :git => 'https://github.com/sutrolabs/karafka-rdkafka.git', branch: 'kt/support-nix'
 
 group :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'concurrent-ruby', '>= 1.1'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.12.3'
+  # TODO: drop karafka-rdkafka in favour of custom gem that doesn't build native extensions on nix
+  # spec.add_dependency 'karafka-rdkafka', '>= 0.12.3'
+  # gem "rdkafka", git: "git@github.com:sutrolabs/karafka-rdkafka.git", branch: "kt/support-nix"
 
   spec.required_ruby_version = '>= 2.6.0'
 

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,9 +17,10 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'concurrent-ruby', '>= 1.1'
-  # TODO: drop karafka-rdkafka in favour of custom gem that doesn't build native extensions on nix
+
+  # Replace karafka-rdkafka in favour of custom gem that doesn't build native extensions on nix
   # spec.add_dependency 'karafka-rdkafka', '>= 0.12.3'
-  # gem "rdkafka", git: "git@github.com:sutrolabs/karafka-rdkafka.git", branch: "kt/support-nix"
+  # gem "rdkafka", github: "sutrolabs/karafka-rdkafka", branch: "kt/support-nix"
 
   spec.required_ruby_version = '>= 2.6.0'
 


### PR DESCRIPTION
## Description of the change

sutrolabs/rdkafka could be configured NOT to build native extensions, which enables to run it on nix

## How tested

> New test cases added, or something else

## Security implications

> What, if any, security implications this change may have
