### PR TITLE
v2.1.1 - Replace karafka/rdkafka dep with sutrolabs/rdkafka #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka core changelog
 
-## 2.1.0 (Unreleased)
-- [Change] Set `karafka-rdkafka` requirement from `>= 0.13.0.beta2` to `<= 0.14.0`.
+## 2.1.0 (2023-06-19)
+- [Change] Set `karafka-rdkafka` requirement from `>= 0.13.0` to `<= 0.14.0`.
 - [Change] Remove no longer needed patch.
 
 ## 2.0.13 (2023-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Karafka core changelog
 
+## 2.1.0 (Unreleased)
+- [Change] Set `karafka-rdkafka` requirement from `>= 0.13.0.beta1` to `<= 0.14.0`.
+- [Change] Remove no longer needed patch.
+
 ## 2.0.13 (2023-05-26)
 - Set minimum `karafka-rdkafka` on `0.12.3`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka core changelog
 
 ## 2.1.0 (Unreleased)
-- [Change] Set `karafka-rdkafka` requirement from `>= 0.13.0.beta1` to `<= 0.14.0`.
+- [Change] Set `karafka-rdkafka` requirement from `>= 0.13.0.beta2` to `<= 0.14.0`.
 - [Change] Remove no longer needed patch.
 
 ## 2.0.13 (2023-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka core changelog
 
+## 2.1.1 (2023-06-28)
+- Set minimum `karafka-rdkafka` on `0.13.1`.
+
 ## 2.1.0 (2023-06-19)
 - [Change] Set `karafka-rdkafka` requirement from `>= 0.13.0` to `<= 0.14.0`.
 - [Change] Remove no longer needed patch.

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,11 @@
 
 source 'https://rubygems.org'
 
-plugin 'diffend'
+# plugin 'diffend'
 
 gemspec
+
+gem "rdkafka", :git => 'https://github.com/sutrolabs/karafka-rdkafka.git', branch: 'kt/0.13.1'
 
 group :test do
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "rdkafka", :git => 'https://github.com/sutrolabs/karafka-rdkafka.git', branch: 'AI/0.13'
+gem "rdkafka", :git => 'https://github.com/sutrolabs/karafka-rdkafka.git', branch: 'AI/0.13-update'
 
 group :test do
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "rdkafka", :git => 'https://github.com/sutrolabs/karafka-rdkafka.git', branch: 'kt/0.13.1'
+gem "rdkafka", :git => 'https://github.com/sutrolabs/karafka-rdkafka.git', branch: 'AI/0.13'
 
 group :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     karafka-core (2.1.0)
       concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.13.0.beta2, < 0.14.0)
+      karafka-rdkafka (>= 0.13.0, < 0.14.0)
 
 GEM
   remote: https://rubygems.org/
@@ -22,7 +22,7 @@ GEM
     ffi (1.15.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    karafka-rdkafka (0.13.0.beta2)
+    karafka-rdkafka (0.13.0)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.0.13)
+    karafka-core (2.1.0)
       concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.12.3)
+      karafka-rdkafka (>= 0.13.0.beta1, < 0.14.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.0.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -20,22 +20,22 @@ GEM
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     ffi (1.15.5)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    karafka-rdkafka (0.12.3)
+    karafka-rdkafka (0.13.0.beta1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    mini_portile2 (2.8.1)
+    mini_portile2 (2.8.2)
     minitest (5.18.0)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.1)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-mocks (3.12.5)
@@ -52,7 +52,6 @@ GEM
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
-  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     karafka-core (2.1.0)
       concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.13.0, < 0.14.0)
+      karafka-rdkafka (>= 0.13.1, < 0.14.0)
 
 GEM
   remote: https://rubygems.org/
@@ -22,7 +22,7 @@ GEM
     ffi (1.15.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    karafka-rdkafka (0.13.0)
+    karafka-rdkafka (0.13.2)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka-core (2.1.0)
+    karafka-core (2.1.1)
       concurrent-ruby (>= 1.1)
       karafka-rdkafka (>= 0.13.1, < 0.14.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     karafka-core (2.1.0)
       concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.13.0.beta1, < 0.14.0)
+      karafka-rdkafka (>= 0.13.0.beta2, < 0.14.0)
 
 GEM
   remote: https://rubygems.org/
@@ -22,7 +22,7 @@ GEM
     ffi (1.15.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    karafka-rdkafka (0.13.0.beta1)
+    karafka-rdkafka (0.13.0.beta2)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/sutrolabs/karafka-rdkafka.git
-  revision: f63e300e2d46dea0a291574014620f17d87a7f49
+  revision: 6297c7944bc338dcfde2814b717e9b2bdc014f48
   branch: AI/0.13-update
   specs:
     rdkafka (0.13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/sutrolabs/karafka-rdkafka.git
-  revision: 1e04dbbbee012b88c2ffa0fe33605bcae3fdb8fe
+  revision: f63e300e2d46dea0a291574014620f17d87a7f49
   branch: AI/0.13-update
   specs:
     rdkafka (0.13.0)
@@ -17,7 +17,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.5)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -29,7 +29,7 @@ GEM
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     ffi (1.16.3)
-    i18n (1.14.1)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     mini_portile2 (2.8.5)
     minitest (5.18.0)
@@ -38,9 +38,9 @@ GEM
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
+    rspec-core (3.12.1)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-mocks (3.12.5)
@@ -57,6 +57,7 @@ GEM
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,18 @@
+GIT
+  remote: https://github.com/sutrolabs/karafka-rdkafka.git
+  revision: 1e04dbbbee012b88c2ffa0fe33605bcae3fdb8fe
+  branch: AI/0.13-update
+  specs:
+    rdkafka (0.13.0)
+      ffi (~> 1.15)
+      mini_portile2 (~> 2.6)
+      rake (> 12)
+
 PATH
   remote: .
   specs:
     karafka-core (2.1.1)
       concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.13.1, < 0.14.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,16 +28,12 @@ GEM
     docile (1.4.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
-    ffi (1.15.5)
+    ffi (1.16.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    karafka-rdkafka (0.13.2)
-      ffi (~> 1.15)
-      mini_portile2 (~> 2.6)
-      rake (> 12)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.5)
     minitest (5.18.0)
-    rake (13.0.6)
+    rake (13.1.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -52,14 +57,16 @@ GEM
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
   byebug
   factory_bot
   karafka-core!
+  rdkafka!
   rspec
   simplecov
 
 BUNDLED WITH
-   2.4.12
+   2.3.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/sutrolabs/karafka-rdkafka.git
-  revision: 6297c7944bc338dcfde2814b717e9b2bdc014f48
+  revision: f6bf821685183985175316adf28db7953f9ad288
   branch: AI/0.13-update
   specs:
     rdkafka (0.13.0)

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'concurrent-ruby', '>= 1.1'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.13.0.beta2', '< 0.14.0'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.13.0', '< 0.14.0'
 
   spec.required_ruby_version = '>= 2.6.0'
 

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'concurrent-ruby', '>= 1.1'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.13.0', '< 0.14.0'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.13.1', '< 0.14.0'
 
   spec.required_ruby_version = '>= 2.6.0'
 

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'concurrent-ruby', '>= 1.1'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.13.0.beta1', '< 0.14.0'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.13.0.beta2', '< 0.14.0'
 
   spec.required_ruby_version = '>= 2.6.0'
 

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'concurrent-ruby', '>= 1.1'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.12.3'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.13.0.beta1', '< 0.14.0'
 
   spec.required_ruby_version = '>= 2.6.0'
 

--- a/karafka-core.gemspec
+++ b/karafka-core.gemspec
@@ -17,7 +17,9 @@ Gem::Specification.new do |spec|
   spec.licenses    = %w[MIT]
 
   spec.add_dependency 'concurrent-ruby', '>= 1.1'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.13.1', '< 0.14.0'
+  # Replace karafka-rdkafka in favour of custom gem that doesn't build native extensions on nix
+  # spec.add_dependency 'karafka-rdkafka', '>= 0.13.1', '< 0.14.0'
+  # gem "rdkafka", github: "sutrolabs/karafka-rdkafka", branch: 'kt/0.13.1'
 
   spec.required_ruby_version = '>= 2.6.0'
 

--- a/lib/karafka/core/patches/rdkafka/bindings.rb
+++ b/lib/karafka/core/patches/rdkafka/bindings.rb
@@ -13,8 +13,6 @@ module Karafka
             # Add extra methods that we need
             # @param mod [::Rdkafka::Bindings] rdkafka bindings module
             def included(mod)
-              mod.attach_function :rd_kafka_name, [:pointer], :string
-
               # Default rdkafka setup for errors doest not propagate client details, thus it always
               # publishes all the stuff for all rdkafka instances. We change that by providing
               # function that fetches the instance name, allowing us to have better notifications

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = '2.1.0'
+    VERSION = '2.1.1'
   end
 end

--- a/lib/karafka/core/version.rb
+++ b/lib/karafka/core/version.rb
@@ -4,6 +4,6 @@ module Karafka
   module Core
     # Current Karafka::Core version
     # We follow the versioning schema of given Karafka version
-    VERSION = '2.0.13'
+    VERSION = '2.1.0'
   end
 end


### PR DESCRIPTION
## Description of the change

v2.1.1 sutrolabs/rdkafka could be configured NOT to build native extensions, which enables to run it on nix

## How tested

> New test cases added, or something else

## Security implications

> What, if any, security implications this change may have
